### PR TITLE
Erro com label com espacos

### DIFF
--- a/dev/pickout.js
+++ b/dev/pickout.js
@@ -347,7 +347,7 @@ var pickout = (function(){
 
 		// Title Option Group
 		if (!!data.optGroup) {
-			var optCreated = _.$('li[data-opt-group='+data.optGroup.label+']', main);
+			var optCreated = _.$('li[data-opt-group='+data.optGroup.label.replace(/\s/g,'')+']', main);
 
 			// Created if not exists
 			if (!optCreated) {


### PR DESCRIPTION
Quando o label tem espaços ele da um erro e nao carrega.

Exemplo: Rio de Janeiro, Santa Catarina e etc